### PR TITLE
change type to dctType

### DIFF
--- a/src/fdk_rdf_parser/classes/dataservice.py
+++ b/src/fdk_rdf_parser/classes/dataservice.py
@@ -31,7 +31,7 @@ class DataService(PartialDcatResource):
         self.theme = values.theme
         self.keyword = values.keyword
         self.contactPoint = values.contactPoint
-        self.type = values.type
+        self.dctType = values.dctType
         self.issued = values.issued
         self.modified = values.modified
         self.landingPage = values.landingPage

--- a/src/fdk_rdf_parser/classes/dataservice.py
+++ b/src/fdk_rdf_parser/classes/dataservice.py
@@ -19,6 +19,7 @@ class DataService(PartialDcatResource):
     servesDataset: Optional[List[str]] = None
     conformsTo: Optional[List[SkosConcept]] = None
     catalog: Optional[Catalog] = None
+    type: str = "dataservices"
 
     def add_values_from_dcat_resource(self: Any, values: PartialDcatResource) -> Any:
         self.identifier = values.identifier

--- a/src/fdk_rdf_parser/classes/dataset.py
+++ b/src/fdk_rdf_parser/classes/dataset.py
@@ -57,7 +57,7 @@ class PartialDataset(PartialDcatResource):
         self.theme = values.theme
         self.keyword = values.keyword
         self.contactPoint = values.contactPoint
-        self.type = values.type
+        self.dctType = values.dctType
         self.issued = values.issued
         self.modified = values.modified
         self.landingPage = values.landingPage
@@ -80,7 +80,7 @@ class Dataset(PartialDataset):
         self.theme = values.theme
         self.keyword = values.keyword
         self.contactPoint = values.contactPoint
-        self.type = values.type
+        self.dctType = values.dctType
         self.issued = values.issued
         self.modified = values.modified
         self.landingPage = values.landingPage

--- a/src/fdk_rdf_parser/classes/dataset.py
+++ b/src/fdk_rdf_parser/classes/dataset.py
@@ -68,6 +68,7 @@ class PartialDataset(PartialDcatResource):
 class Dataset(PartialDataset):
     publisher: Optional[Publisher] = None
     losTheme: Optional[List[ThemeLOS]] = None
+    type: str = "datasets"
 
     def add_values_from_partial(self: Any, values: PartialDataset) -> None:
         self.id = values.id

--- a/src/fdk_rdf_parser/classes/dcat_resource.py
+++ b/src/fdk_rdf_parser/classes/dcat_resource.py
@@ -19,7 +19,7 @@ class PartialDcatResource:
     theme: Optional[List[ThemeEU]] = None
     keyword: Optional[List[Dict[str, str]]] = None
     contactPoint: Optional[List[ContactPoint]] = None
-    type: Optional[str] = None
+    dctType: Optional[str] = None
     issued: Optional[str] = None
     modified: Optional[str] = None
     landingPage: Optional[List[str]] = None

--- a/src/fdk_rdf_parser/parse_functions/dcat_resource.py
+++ b/src/fdk_rdf_parser/parse_functions/dcat_resource.py
@@ -34,7 +34,7 @@ def parse_dcat_resource(
         theme=extract_themes(graph, subject),
         keyword=extract_key_words(graph, subject),
         contactPoint=extract_contact_points(graph, subject),
-        type=object_value(graph, subject, DCTERMS.type),
+        dctType=object_value(graph, subject, DCTERMS.type),
         issued=date_value(graph, subject, DCTERMS.issued),
         modified=date_value(graph, subject, DCTERMS.modified),
         landingPage=value_list(graph, subject, dcat_uri("landingPage")),

--- a/tests/test_dcat_resource.py
+++ b/tests/test_dcat_resource.py
@@ -73,7 +73,7 @@ def test_dcat_resource_parser() -> None:
             SkosCode(uri="http://pubs.europa.eu/resource/authority/language/NOR")
         ],
         landingPage=["https://testdirektoratet.no"],
-        type="Kodelister",
+        dctType="Kodelister",
     )
 
     graph = Graph().parse(data=src, format="turtle")


### PR DESCRIPTION
I fdk-fulltext-search overskrives feltet 'type' med navnet på indexen i elastic, ref: https://github.com/Informasjonsforvaltning/fdk-fulltext-search/blob/086009e0420ace6bbb757a73f31aef7764c406ec/src/search/responses.py#L49

Med dette så mister vi ikke dataen fra dct:type og er et steg på vegen mot å kunne fjerne det at fulltext modifiserer dataen.