### PR TITLE
fix: match all environments when extracting orgnr from uri

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ locations = "src", "tests", "noxfile.py"
 def tests(session: Session) -> None:
     args = session.posargs or ["--cov", "-m", "not e2e"]
     env = {
-        "ORGANIZATION_CATALOGUE_BASE_URI": "https://organizations.fellestestkatalog.no"
+        "ORGANIZATION_CATALOGUE_BASE_URI": "https://organizations.fellesdatakatalog.digdir.no"
     }
     nox_poetry.install(session, nox_poetry.WHEEL)
     nox_poetry.install(session, "coverage[toml]", "pytest", "pytest-cov", "pytest-mock")

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,15 +16,15 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.2.0"
+version = "20.3.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
@@ -589,8 +589,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 bandit = [
     {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "0.2.1"
+version = "0.2.2"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 

--- a/src/fdk_rdf_parser/organizations/utils.py
+++ b/src/fdk_rdf_parser/organizations/utils.py
@@ -21,8 +21,7 @@ def org_path_url(org: str) -> str:
 
 
 def organization_number_from_uri(uri: str) -> Optional[str]:
-    match_uri_0 = "https://data.brreg.no/enhetsregisteret/api/enheter/"
-    match_uri_1 = base_org_url + "/organizations/"
-    match_str = "^(?:" + match_uri_0 + "|" + match_uri_1 + ")(\\d{9})$"
-    match = re.compile(match_str).match(uri)
-    return match.group(1) if match else None
+    if "data.brreg.no/" in uri or "fellesdatakatalog.digdir.no/organizations/" in uri:
+        matches = re.findall("[0-9]{9}", uri)
+        return matches[0] if len(matches) == 1 else None
+    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def mock_orgpath_client(mocker: MockFixture) -> Mock:
 def mock_organizations_error(mocker: MockFixture) -> Mock:
     mock = mocker.patch("requests.get")
     mock.side_effect = requests.HTTPError(
-        "https://organizations.fellestestkatalog.no/organizations/123456789",
+        "https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         404,
         "Not Found",
         {},

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -108,7 +108,7 @@ def test_parse_multiple_data_services(
     expected = {
         "https://testutgiver.no/data-services/2": DataService(
             publisher=Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                 id="123456789",
                 name="Digitaliseringsdirektoratet",
                 orgPath="/STAT/987654321/123456789",
@@ -170,7 +170,7 @@ def test_parse_multiple_data_services(
                 uri="https://testutgiver.no/catalogs/123456789",
                 title={"en": "Data service catalog"},
                 publisher=Publisher(
-                    uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                    uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                     id="123456789",
                     name="Digitaliseringsdirektoratet",
                     orgPath="/STAT/987654321/123456789",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -72,7 +72,7 @@ def test_parse_multiple_datasets(mock_organizations_and_reference_data: Mock) ->
                 changed=["2020-03-12T11:52:16Z", "2020-03-12T11:52:16Z"],
             ),
             publisher=Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                 id="123456789",
                 name="Digitaliseringsdirektoratet",
                 orgPath="/STAT/987654321/123456789",
@@ -161,7 +161,7 @@ def test_adds_catalog_to_dataset(mock_organizations_and_reference_data: Mock,) -
             ),
             uri="https://testdirektoratet.no/model/dataset/0",
             publisher=Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                 id="123456789",
                 name="Digitaliseringsdirektoratet",
                 orgPath="/STAT/987654321/123456789",
@@ -178,7 +178,7 @@ def test_adds_catalog_to_dataset(mock_organizations_and_reference_data: Mock,) -
                 title={"nb": "Katalog"},
                 description={"nb": "Beskrivelse av katalog"},
                 publisher=Publisher(
-                    uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                    uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                     id="123456789",
                     name="Digitaliseringsdirektoratet",
                     orgPath="/STAT/987654321/123456789",
@@ -577,7 +577,7 @@ def test_qualified_attributions(mock_organizations_client: Mock) -> None:
         qualifiedAttributions=[
             QualifiedAttribution(
                 agent=Publisher(
-                    uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+                    uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
                     id="123456789",
                     name="Digitaliseringsdirektoratet",
                     orgPath="/STAT/987654321/123456789",
@@ -592,7 +592,7 @@ def test_qualified_attributions(mock_organizations_client: Mock) -> None:
             ),
             QualifiedAttribution(
                 agent=Publisher(
-                    uri="https://organizations.fellestestkatalog.no/organizations/111111111",
+                    uri="https://organizations.fellesdatakatalog.digdir.no/organizations/111111111",
                     id="111111111",
                     name="Pythondirektoratet",
                     orgPath="/STAT/987654321/111111111",

--- a/tests/test_info_model.py
+++ b/tests/test_info_model.py
@@ -101,7 +101,7 @@ digdir:Diversemodell  a    modelldcatno:InformationModel , owl:NamedIndividual ;
                 "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Diversemodell"
             ],
             publisher=Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/991825827",
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/991825827",
                 prefLabel={"nb": "Digitaliseringsdirektoratet"},
             ),
             title={"nb": "Diversemodell"},
@@ -284,7 +284,7 @@ digdir:Katalog  a           dcat:Catalog , owl:NamedIndividual ;
     expected = {
         "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Diversemodell": InformationModel(
             publisher=Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/991825827",
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/991825827",
                 prefLabel={"nb": "Digitaliseringsdirektoratet"},
             ),
             uri="https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Diversemodell",
@@ -295,7 +295,7 @@ digdir:Katalog  a           dcat:Catalog , owl:NamedIndividual ;
             catalog=Catalog(
                 id="03953a9d-5b6b-34ec-b41c-dcdcb21874d9",
                 publisher=Publisher(
-                    uri="https://organizations.fellestestkatalog.no/organizations/991825827",
+                    uri="https://organizations.fellesdatakatalog.digdir.no/organizations/991825827",
                     prefLabel={"nb": "Digitaliseringsdirektoratet"},
                 ),
                 title={"nb": "Digitaliseringsdirektoratets modellkatalog"},

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -13,7 +13,7 @@ from .testdata import org_response_0, org_response_1
 def test_publisher_from_get_all() -> None:
 
     expected = Publisher(
-        uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+        uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         id="123456789",
         name="Digitaliseringsdirektoratet",
         orgPath="/STAT/987654321/123456789",
@@ -39,7 +39,7 @@ def test_publisher_from_get_all() -> None:
 def test_publisher_not_present_in_get_all(mock_organizations_client: Mock) -> None:
 
     expected = Publisher(
-        uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+        uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         id="123456789",
         name="Digitaliseringsdirektoratet",
         orgPath="/STAT/987654321/123456789",
@@ -80,7 +80,7 @@ def test_publisher_not_found(mock_organizations_error: Mock) -> None:
 def test_original_pref_label_is_retained(mock_organizations_client: Mock) -> None:
 
     expected = Publisher(
-        uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+        uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         id="123456789",
         name="Digitaliseringsdirektoratet",
         orgPath="/STAT/987654321/123456789",
@@ -125,7 +125,7 @@ def test_orgpath(mock_orgpath_client: Mock) -> None:
 def test_extract_publisher_id_from_enhetsregisteret_uri() -> None:
 
     expected = Publisher(
-        uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+        uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         id="123456789",
         name="Digitaliseringsdirektoratet",
         orgPath="/STAT/987654321/123456789",
@@ -153,7 +153,7 @@ def test_extract_publisher_id_from_enhetsregisteret_uri() -> None:
 def test_extract_publisher_id_from_org_uri() -> None:
 
     expected = Publisher(
-        uri="https://organizations.fellestestkatalog.no/organizations/123456789",
+        uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789",
         id="123456789",
         name="Digitaliseringsdirektoratet",
         orgPath="/STAT/987654321/123456789",
@@ -170,7 +170,7 @@ def test_extract_publisher_id_from_org_uri() -> None:
     assert (
         publisher_from_fdk_org_catalog(
             Publisher(
-                uri="https://organizations.fellestestkatalog.no/organizations/123456789"
+                uri="https://organizations.fellesdatakatalog.digdir.no/organizations/123456789"
             ),
             orgs_graph,
         )

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -11,9 +11,9 @@ org_response_0 = """
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
-<https://organizations.fellestestkatalog.no/organizations/123456789>
+<https://organizations.fellesdatakatalog.digdir.no/organizations/123456789>
         a                      rov:RegisteredOrganization ;
-        org:subOrganizationOf  <https://organizations.fellestestkatalog.no/organizations/987654321> ;
+        org:subOrganizationOf  <https://organizations.fellesdatakatalog.digdir.no/organizations/987654321> ;
         rov:legalName          "Digitaliseringsdirektoratet" ;
         rov:orgType            "ORGL" ;
         rov:registration       [ a                  adms:Identifier ;
@@ -28,9 +28,9 @@ org_response_0 = """
         br:orgPath             "/STAT/987654321/123456789" ;
         br:sectorCode          "6100" .
 
-<https://organizations.fellestestkatalog.no/organizations/111111111>
+<https://organizations.fellesdatakatalog.digdir.no/organizations/111111111>
         a                      rov:RegisteredOrganization ;
-        org:subOrganizationOf  <https://organizations.fellestestkatalog.no/organizations/111111111> ;
+        org:subOrganizationOf  <https://organizations.fellesdatakatalog.digdir.no/organizations/111111111> ;
         rov:legalName          "Pythondirektoratet" ;
         rov:orgType            "ORGL" ;
         rov:registration       [ a                  adms:Identifier ;
@@ -55,7 +55,7 @@ org_response_1 = """
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
-<https://organizations.fellestestkatalog.no/organizations/987654321>
+<https://organizations.fellesdatakatalog.digdir.no/organizations/987654321>
         a                      rov:RegisteredOrganization ;
         rov:legalName          "Testdirektoratet" ;
         rov:orgType            "ORGL" ;


### PR DESCRIPTION
Det viktigste blir at `https://organization-catalogue.fellesdatakatalog.digdir.no/organizations/{id}` nå skal fungere som publisher i demo/staging