### PR TITLE
Fix/not/correctly parse lagal resource

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -45,25 +45,24 @@ stevedore = ">=1.20.0"
 
 [[package]]
 name = "black"
-version = "20.8b1"
+version = "21.4b2"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.6,<1"
+pathspec = ">=0.8.1,<1"
 regex = ">=2020.1.8"
 toml = ">=0.10.1"
-typed-ast = ">=1.4.0"
-typing-extensions = ">=3.7.4"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+python2 = ["typed-ast (>=1.4.2)"]
 
 [[package]]
 name = "certifi"
@@ -239,14 +238,15 @@ smmap = ">=3.0.1,<5"
 
 [[package]]
 name = "gitpython"
-version = "3.1.14"
+version = "3.1.15"
 description = "Python Git Library"
 category = "dev"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.5"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
+typing-extensions = ">=3.7.4.0"
 
 [[package]]
 name = "idna"
@@ -328,7 +328,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pbr"
-version = "5.5.1"
+version = "5.6.0"
 description = "Python Build Reasonableness"
 category = "dev"
 optional = false
@@ -426,11 +426,11 @@ testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist",
 
 [[package]]
 name = "pytest-mock"
-version = "3.5.1"
+version = "3.6.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 pytest = ">=5.0"
@@ -572,7 +572,7 @@ brotli = ["brotlipy (>=0.6.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ec7711fe720bdf8514dda8c00afdbdb48e240b6e0e75f87fda34d18afd561096"
+content-hash = "4b98fbb7d99515e50af044fc1a5c02c750a4085d26656082bda2a2e0efd76959"
 
 [metadata.files]
 appdirs = [
@@ -592,7 +592,8 @@ bandit = [
     {file = "bandit-1.7.0.tar.gz", hash = "sha256:8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608"},
 ]
 black = [
-    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+    {file = "black-21.4b2-py3-none-any.whl", hash = "sha256:bff7067d8bc25eb21dcfdbc8c72f2baafd9ec6de4663241a52fb904b304d391f"},
+    {file = "black-21.4b2.tar.gz", hash = "sha256:fc9bcf3b482b05c1f35f6a882c079dc01b9c7795827532f4cc43c0ec88067bbc"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -701,8 +702,8 @@ gitdb = [
     {file = "gitdb-4.0.7.tar.gz", hash = "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.14-py3-none-any.whl", hash = "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b"},
-    {file = "GitPython-3.1.14.tar.gz", hash = "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"},
+    {file = "GitPython-3.1.15-py3-none-any.whl", hash = "sha256:a77824e516d3298b04fb36ec7845e92747df8fcfee9cacc32dd6239f9652f867"},
+    {file = "GitPython-3.1.15.tar.gz", hash = "sha256:05af150f47a5cca3f4b0af289b73aef8cf3c4fe2385015b06220cbcdee48bb6e"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -757,8 +758,8 @@ pathspec = [
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pbr = [
-    {file = "pbr-5.5.1-py2.py3-none-any.whl", hash = "sha256:b236cde0ac9a6aedd5e3c34517b423cd4fd97ef723849da6b0d2231142d89c00"},
-    {file = "pbr-5.5.1.tar.gz", hash = "sha256:5fad80b613c402d5b7df7bd84812548b2a61e9977387a80a5fc5c396492b13c9"},
+    {file = "pbr-5.6.0-py2.py3-none-any.whl", hash = "sha256:c68c661ac5cc81058ac94247278eeda6d2e6aecb3e227b0387c30d277e7ef8d4"},
+    {file = "pbr-5.6.0.tar.gz", hash = "sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd"},
 ]
 pep8-naming = [
     {file = "pep8-naming-0.11.1.tar.gz", hash = "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724"},
@@ -793,8 +794,8 @@ pytest-cov = [
     {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
-    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
+    {file = "pytest-mock-3.6.0.tar.gz", hash = "sha256:f7c3d42d6287f4e45846c8231c31902b6fa2bea98735af413a43da4cf5b727f1"},
+    {file = "pytest_mock-3.6.0-py3-none-any.whl", hash = "sha256:952139a535b5b48ac0bb2f90b5dd36b67c7e1ba92601f3a8012678c4bd7f0bcc"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "0.3.7"
+version = "0.3.8"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 
@@ -14,7 +14,7 @@ requests = "^2.23.0"
 pytest = "^6.2.3"
 coverage = {extras = ["toml"], version = "^5.5"}
 pytest-cov = "^2.8.1"
-black = "^20.8b1"
+black = "^21.4b2"
 flake8 = "^3.9.1"
 flake8-bandit = "^2.1.2"
 flake8-black = "^0.2.1"
@@ -22,7 +22,7 @@ flake8-bugbear = "^21.4.3"
 flake8-import-order = "^0.18.1"
 pep8-naming = "^0.11.1"
 safety = "^1.8.7"
-pytest-mock = "^3.1.0"
+pytest-mock = "^3.6.0"
 codecov = "^2.0.22"
 flake8-annotations = "^2.6.2"
 mypy = "^0.812"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -690,6 +690,8 @@ def test_dcat_ap_no_2_rules(mock_organizations_and_reference_data: Mock) -> None
         @prefix dct: <http://purl.org/dc/terms/> .
         @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
         @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+        @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+        @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
         @prefix cpsv: <http://purl.org/vocab/cpsv#> .
         @prefix cpsvno: <https://data.norge.no/vocabulary/cpsvno#> .
         @prefix eli: <http://data.europa.eu/eli/ontology#> .
@@ -707,22 +709,25 @@ def test_dcat_ap_no_2_rules(mock_organizations_and_reference_data: Mock) -> None
             cpsv:follows [ a cpsv:Rule ;
                     dct:type cpsvno:ruleForNonDisclosure ;
                     cpsv:implements [ a eli:LegalResouce ;
-                        xsd:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-1" ;
-                        dct:title "Skatteforvaltningsloven §3-1"@nb ;
-                  ] ;
+                        rdfs:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-1" ;
+                        dct:type    [ a skos:Concept ;
+                            skos:prefLabel  "Skatteforvaltningsloven §3-1"@nb ;
+                        ]
+                    ] ;
                 ] ,
                 [ a cpsv:Rule ;
                     dct:type cpsvno:ruleForDisclosure ;
                     cpsv:implements [ a eli:LegalResouce ;
-                        xsd:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-3" ;
-                        dct:title "Skatteforvaltningsloven §§ 3-3 til 3-9"@nb ;
+                        rdfs:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-3" ;
+                        dct:type    [ a skos:Concept ;
+                            skos:prefLabel  "Skatteforvaltningsloven §§ 3-3 til 3-9"@nb ;
+                        ]
                     ] ;
                 ] ,
                 [ a cpsv:Rule ;
                     dct:type cpsvno:ruleForDataProcessing ;
                     cpsv:implements [ a eli:LegalResouce ;
-                        xsd:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-3" ;
-                        dct:title "Skatteforvaltningsloven §§ 3-3 til 3-9"@nb ;
+                        rdfs:seeAlso "https://lovdata.no/NL/lov/2016-05-27-14/§3-3" ;
                     ] ;
                 ] ,
                 [ a cpsv:Rule ;
@@ -742,21 +747,20 @@ def test_dcat_ap_no_2_rules(mock_organizations_and_reference_data: Mock) -> None
                 SkosConcept(
                     uri="https://lovdata.no/NL/lov/2016-05-27-14/§3-1",
                     prefLabel={"nb": "Skatteforvaltningsloven §3-1"},
-                    extraType="http://purl.org/vocab/cpsv#Rule",
+                    extraType="https://data.norge.no/vocabulary/cpsvno#ruleForNonDisclosure",
                 )
             ],
             legalBasisForProcessing=[
                 SkosConcept(
                     uri="https://lovdata.no/NL/lov/2016-05-27-14/§3-3",
-                    prefLabel={"nb": "Skatteforvaltningsloven §§ 3-3 til 3-9"},
-                    extraType="http://purl.org/vocab/cpsv#Rule",
+                    extraType="https://data.norge.no/vocabulary/cpsvno#ruleForDataProcessing",
                 )
             ],
             legalBasisForAccess=[
                 SkosConcept(
                     uri="https://lovdata.no/NL/lov/2016-05-27-14/§3-3",
                     prefLabel={"nb": "Skatteforvaltningsloven §§ 3-3 til 3-9"},
-                    extraType="http://purl.org/vocab/cpsv#Rule",
+                    extraType="https://data.norge.no/vocabulary/cpsvno#ruleForDisclosure",
                 )
             ],
         ),


### PR DESCRIPTION
Fra ny spekk:

```
:aDataset
   a dcat:Dataset ;
   cpsv:follows :aNonDisclosureRule, :aDisclosureRule .

:aNonDisclosureRule
   a cpsv:Rule ;
   dct:type cpsvno:ruleForNonDisclosure ;
   dct:description "skjerminghjemmel"@nb , "legal basis for non-disclosure"@en .

:aDisclosureRule
   a cpsv:Rule ;
   dct:type cpsvno:ruleForDisclosure ;
   dct:description "utleveringshjemmel"@nb , "legal basis for disclosure"@en ;
   cpsv:implements :aLegalResource .

:aLegalResource
   a eli:LegalResource ;
   dct:type [ a skos:Concept ;
      skos:prefLabel "lov"@nb ;
      skos:definition "rettsregler som fastsetter rettigheter og plikter"@nb ;
      ] ;
   dct:description "Eksempelregelverk"@nb , "Example legal resource"@en ;
   rdfs:seeAlso <https:/example.com/eli/lov/2020/01/01/section/1> .

der cpsvno:ruleForNonDisclosure (skjermingsregel) og cpsvno:ruleForDisclosure (utleveringsegel)
er predefinerte instanser av type regel (skos:Concept).
```