### PR TITLE
fix(info_model): extend dct:hasFormat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "0.3.8"
+version = "0.3.9"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 

--- a/src/fdk_rdf_parser/classes/__init__.py
+++ b/src/fdk_rdf_parser/classes/__init__.py
@@ -13,6 +13,7 @@ from .dcat_resource import PartialDcatResource
 from .distribution import Distribution
 from .event import Event
 from .evidence import Evidence
+from .format import Format
 from .harvest_meta_data import HarvestMetaData
 from .info_model import InformationModel
 from .legal_resource import LegalResource

--- a/src/fdk_rdf_parser/classes/format.py
+++ b/src/fdk_rdf_parser/classes/format.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .skos_code import SkosCode
+
+
+@dataclass
+class Format:
+    uri: Optional[str] = None
+    title: Optional[Dict[str, str]] = None
+    format: Optional[str] = None
+    language: Optional[SkosCode] = None

--- a/src/fdk_rdf_parser/classes/info_model.py
+++ b/src/fdk_rdf_parser/classes/info_model.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from .catalog import Catalog
 from .dcat_resource import PartialDcatResource
+from .format import Format
 from .harvest_meta_data import HarvestMetaData
 from .model_element import ModelElement
 from .model_property import ModelProperty
@@ -25,7 +26,7 @@ class InformationModel(PartialDcatResource):
     isReplacedBy: Optional[str] = None
     replaces: Optional[str] = None
     temporal: Optional[List[Temporal]] = None
-    hasFormat: Optional[Set[str]] = None
+    hasFormat: Optional[List[Format]] = None
     homepage: Optional[str] = None
     status: Optional[str] = None
     versionInfo: Optional[str] = None

--- a/src/fdk_rdf_parser/parse_functions/__init__.py
+++ b/src/fdk_rdf_parser/parse_functions/__init__.py
@@ -11,6 +11,7 @@ from .dcat_resource import parse_dcat_resource
 from .distribution import extract_distributions
 from .event import extend_with_associated_broader_types, parse_event
 from .evidence import extract_evidences
+from .format import extract_formats
 from .harvest_meta_data import extract_meta_data
 from .info_model import parse_information_model
 from .legal_resource import extract_legal_resources

--- a/src/fdk_rdf_parser/parse_functions/format.py
+++ b/src/fdk_rdf_parser/parse_functions/format.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+
+from rdflib import Graph, URIRef
+from rdflib.namespace import DCTERMS
+
+from fdk_rdf_parser.classes import Format
+from fdk_rdf_parser.rdf_utils import (
+    dct_uri,
+    object_value,
+    resource_list,
+    value_translations,
+)
+from .dcat_resource import extract_skos_code
+
+
+def extract_formats(graph: Graph, subject: URIRef) -> Optional[List[Format]]:
+    values = []
+    for resource in resource_list(graph, subject, DCTERMS.hasFormat):
+        format_uri = resource.toPython() if isinstance(resource, URIRef) else None
+        values.append(
+            Format(
+                uri=format_uri,
+                title=value_translations(graph, resource, DCTERMS.title),
+                format=object_value(graph, resource, dct_uri("format")),
+                language=extract_skos_code(graph, resource, DCTERMS.language),
+            )
+        )
+
+    return values if len(values) > 0 else None

--- a/src/fdk_rdf_parser/parse_functions/info_model.py
+++ b/src/fdk_rdf_parser/parse_functions/info_model.py
@@ -16,6 +16,7 @@ from fdk_rdf_parser.rdf_utils import (
 )
 from .catalog import parse_catalog
 from .dcat_resource import parse_dcat_resource
+from .format import extract_formats
 from .harvest_meta_data import extract_meta_data
 from .model_element import parse_model_element
 from .model_property import parse_model_property
@@ -46,7 +47,7 @@ def parse_information_model(
         hasPart=object_value(graph, info_model_uri, DCTERMS.hasPart),
         isReplacedBy=object_value(graph, info_model_uri, DCTERMS.isReplacedBy),
         replaces=object_value(graph, info_model_uri, DCTERMS.replaces),
-        hasFormat=value_set(graph, info_model_uri, DCTERMS.hasFormat),
+        hasFormat=extract_formats(graph, info_model_uri),
         homepage=object_value(graph, info_model_uri, FOAF.homepage),
         status=object_value(graph, info_model_uri, adms_uri("status")),
         versionInfo=object_value(graph, info_model_uri, OWL.versionInfo),

--- a/tests/test_info_model.py
+++ b/tests/test_info_model.py
@@ -6,6 +6,7 @@ from fdk_rdf_parser import parse_information_models
 from fdk_rdf_parser.classes import (
     Catalog,
     ContactPoint,
+    Format,
     HarvestMetaData,
     InformationModel,
     Publisher,
@@ -56,7 +57,7 @@ digdir:Utgiver  a       foaf:Agent , owl:NamedIndividual ;
 
 digdir:Diversemodell  a    modelldcatno:InformationModel , owl:NamedIndividual ;
         dct:description    "Modell med diverse i. Inneholder modellelementer som AltMuligModell skal peke til."@nb ;
-        dct:hasFormat      digdir:AlternativModellformat ;
+        dct:hasFormat      <https://github.com/statisticsnorway/gsim-raml-schema/blob/master/ssb_gsim_ldm.png> ;
         dct:identifier     "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Diversemodell" ;
         dct:isPartOf       digdir:AltMuligModell ;
         dct:isReplacedBy   digdir:AdresseModell ;
@@ -78,6 +79,12 @@ digdir:Diversemodell  a    modelldcatno:InformationModel , owl:NamedIndividual ;
         foaf:homepage      <https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/nasjonal-arkitektur/informasjonsforvaltning/adresse-felles-informasjonsmodell> ;
         modelldcatno:informationModelIdentifier
                 "https://www.digdir.no/diversemodell" .
+
+<https://github.com/statisticsnorway/gsim-raml-schema/blob/master/ssb_gsim_ldm.png>
+        a           foaf:Document ;
+        dct:format  <http://publications.europa.eu/resource/authority/file-type/PNG> ;
+        dct:language <http://pubs.europa.eu/resource/authority/language/NOR> ;
+        dct:title   "Image of the logical data model (LDM)"@en .
 
 <https://informationmodels.staging.fellesdatakatalog.digdir.no/informationmodels/77e07f69-5fb4-30c7-afca-bffe179dc3b3>
         a                  dcat:CatalogRecord ;
@@ -162,9 +169,16 @@ digdir:Diversemodell  a    modelldcatno:InformationModel , owl:NamedIndividual ;
                     startDate="2016-02-11T00:00:00+01:00",
                 )
             ],
-            hasFormat={
-                "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#AlternativModellformat"
-            },
+            hasFormat=[
+                Format(
+                    uri="https://github.com/statisticsnorway/gsim-raml-schema/blob/master/ssb_gsim_ldm.png",
+                    title={"en": "Image of the logical data model (LDM)"},
+                    format="http://publications.europa.eu/resource/authority/file-type/PNG",
+                    language=SkosCode(
+                        uri="http://pubs.europa.eu/resource/authority/language/NOR",
+                    ),
+                )
+            ],
             homepage="https://www.difi.no/fagomrader-og-tjenester/digitalisering-og-samordning/nasjonal-arkitektur/informasjonsforvaltning/adresse-felles-informasjonsmodell",
             status="http://purl.org/adms/status/Completed",
             versionInfo="1.0",


### PR DESCRIPTION
Informasjonsmodell-klassen (modelldcatno:InformationModel) kan ha egenskapen dct:hasFormat med range foaf:Document: https://data.norge.no/specification/modelldcat-ap-no/#Informasjonsmodell-finnesIFormat