### PR TITLE
fix: stop parsing concept definition & contact as lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "0.3.10"
+version = "0.3.11"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 

--- a/src/fdk_rdf_parser/classes/concept.py
+++ b/src/fdk_rdf_parser/classes/concept.py
@@ -35,7 +35,7 @@ class Definition:
 @dataclass
 class Concept:
     id: Optional[str] = None
-    uri: Optional[str] = None
+    identifier: Optional[str] = None
     harvest: Optional[HarvestMetaData] = None
     collection: Optional[Collection] = None
     publisher: Optional[Publisher] = None

--- a/src/fdk_rdf_parser/classes/concept.py
+++ b/src/fdk_rdf_parser/classes/concept.py
@@ -45,8 +45,8 @@ class Concept:
     prefLabel: Optional[Dict[str, str]] = None
     hiddenLabel: Optional[List[Dict[str, str]]] = None
     altLabel: Optional[List[Dict[str, str]]] = None
-    contactPoint: Optional[List[ContactPoint]] = None
-    definition: Optional[List[Definition]] = None
+    contactPoint: Optional[ContactPoint] = None
+    definition: Optional[Definition] = None
     seeAlso: Optional[Set[str]] = None
     validFromIncluding: Optional[str] = None
     validToIncluding: Optional[str] = None

--- a/src/fdk_rdf_parser/parse_functions/concept.py
+++ b/src/fdk_rdf_parser/parse_functions/concept.py
@@ -161,7 +161,7 @@ def parse_concept(graph: Graph, fdk_record_uri: URIRef, concept_uri: URIRef) -> 
 
     return Concept(
         id=object_value(graph, fdk_record_uri, DCTERMS.identifier),
-        uri=concept_uri.toPython(),
+        identifier=concept_uri.toPython(),
         harvest=extract_meta_data(graph, fdk_record_uri),
         collection=parse_collection(graph, fdk_record_uri),
         publisher=extract_publisher(

--- a/src/fdk_rdf_parser/parse_functions/concept.py
+++ b/src/fdk_rdf_parser/parse_functions/concept.py
@@ -88,9 +88,7 @@ def parse_definition(graph: Graph, definition_ref: URIRef) -> Definition:
     )
 
 
-def extract_definitions(
-    graph: Graph, concept_uri: URIRef
-) -> Optional[List[Definition]]:
+def extract_definition(graph: Graph, concept_uri: URIRef) -> Optional[Definition]:
     definitions = []
     for definition_ref in graph.objects(concept_uri, skosno_uri("definisjon")):
         definitions.append(parse_definition(graph, definition_ref))
@@ -98,7 +96,7 @@ def extract_definitions(
         concept_uri, skosno_old_uri("betydningsbeskrivelse")
     ):
         definitions.append(parse_definition(graph, definition_ref))
-    return definitions if len(definitions) > 0 else None
+    return definitions[0] if len(definitions) > 0 else None
 
 
 def parse_collection(graph: Graph, concept_record_uri: URIRef) -> Optional[Collection]:
@@ -157,6 +155,7 @@ def parse_concept(graph: Graph, fdk_record_uri: URIRef, concept_uri: URIRef) -> 
 
     concept_temporal_list = extract_temporal(graph, concept_uri)
     concept_temporal = concept_temporal_list[0] if concept_temporal_list else Temporal()
+    contact_points = extract_contact_points(graph, concept_uri)
 
     pref_label_list = parse_label_set(graph, concept_uri, skosxl_uri("prefLabel"))
 
@@ -176,8 +175,8 @@ def parse_concept(graph: Graph, fdk_record_uri: URIRef, concept_uri: URIRef) -> 
         else None,
         hiddenLabel=parse_label_set(graph, concept_uri, skosxl_uri("hiddenLabel")),
         altLabel=parse_label_set(graph, concept_uri, skosxl_uri("altLabel")),
-        contactPoint=extract_contact_points(graph, concept_uri),
-        definition=extract_definitions(graph, concept_uri),
+        contactPoint=contact_points[0] if contact_points else None,
+        definition=extract_definition(graph, concept_uri),
         seeAlso=value_set(graph, concept_uri, RDFS.seeAlso),
         validFromIncluding=concept_temporal.startDate,
         validToIncluding=concept_temporal.endDate,

--- a/tests/test_concept.py
+++ b/tests/test_concept.py
@@ -163,7 +163,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
     expected = {
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/1843b048-f9af-4665-8e53-3c001d0166c0": Concept(
             id="55a38009-e114-301f-aa7c-8b5f09529f0f",
-            uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/1843b048-f9af-4665-8e53-3c001d0166c0",
+            identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/1843b048-f9af-4665-8e53-3c001d0166c0",
             harvest=HarvestMetaData(
                 firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
             ),
@@ -185,7 +185,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/3609b02d-72c5-47e0-a6b8-df0a503cf190": Concept(
             id="fc8baf8d-6146-3b69-93c5-52bd41592c4e",
-            uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/3609b02d-72c5-47e0-a6b8-df0a503cf190",
+            identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/3609b02d-72c5-47e0-a6b8-df0a503cf190",
             harvest=HarvestMetaData(
                 firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
             ),
@@ -212,7 +212,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/9f25b5ad-8aa7-4233-853b-7434e20aeaef": Concept(
             id="71f860be-ad4c-3ae7-8344-c0b727d4d3b0",
-            uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/9f25b5ad-8aa7-4233-853b-7434e20aeaef",
+            identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/9f25b5ad-8aa7-4233-853b-7434e20aeaef",
             harvest=HarvestMetaData(
                 firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
             ),
@@ -244,7 +244,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3": Concept(
             id="35367473-a4c0-3f55-bbdb-fcdbffb6f67a",
-            uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3",
+            identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3",
             harvest=HarvestMetaData(
                 firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
             ),
@@ -270,7 +270,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/c4ae179e-6a3a-42bc-85a2-1e32d75fc013": Concept(
             id="bb4a8fa6-16ba-3dc9-92e6-42773dc985de",
-            uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/c4ae179e-6a3a-42bc-85a2-1e32d75fc013",
+            identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/c4ae179e-6a3a-42bc-85a2-1e32d75fc013",
             harvest=HarvestMetaData(
                 firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
             ),
@@ -339,7 +339,7 @@ def test_parse_concept_handles_wrong_collection_type(
 
     expected = Concept(
         id="55a38009-e114-301f-aa7c-8b5f09529f0f",
-        uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/1843b048-f9af-4665-8e53-3c001d0166c0",
+        identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/1843b048-f9af-4665-8e53-3c001d0166c0",
         harvest=HarvestMetaData(
             firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
         ),
@@ -398,7 +398,7 @@ def test_parse_concept_with_old_skosno(
 
     expected = Concept(
         id="35367473-a4c0-3f55-bbdb-fcdbffb6f67a",
-        uri="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3",
+        identifier="https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3",
         harvest=HarvestMetaData(
             firstHarvested="2021-02-17T09:39:13Z", changed=["2021-02-17T09:39:13Z"]
         ),

--- a/tests/test_concept.py
+++ b/tests/test_concept.py
@@ -180,11 +180,7 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
             ),
             prefLabel={"nb": "to"},
             altLabel=[{"nb": "w"}],
-            definition=[
-                Definition(
-                    text={"nb": "dfgfg"},
-                )
-            ],
+            definition=Definition(text={"nb": "dfgfg"}),
             type="concept",
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/3609b02d-72c5-47e0-a6b8-df0a503cf190": Concept(
@@ -206,14 +202,12 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
             ),
             prefLabel={"nb": "midtbaneanker"},
             altLabel=[{"nb": "stabilisator"}],
-            definition=[
-                Definition(
-                    text={"nb": "en stabil stabilisator på midten"},
-                    sourceRelationship="egendefinert",
-                    targetGroup="fagspesialist",
-                    sources=[TextAndURI(uri=None, text=None)],
-                )
-            ],
+            definition=Definition(
+                text={"nb": "en stabil stabilisator på midten"},
+                sourceRelationship="egendefinert",
+                targetGroup="fagspesialist",
+                sources=[TextAndURI(uri=None, text=None)],
+            ),
             type="concept",
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/9f25b5ad-8aa7-4233-853b-7434e20aeaef": Concept(
@@ -235,19 +229,17 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
             ),
             application=[{"nb": "arbeid"}],
             prefLabel={"nn": "dokument"},
-            definition=[
-                Definition(
-                    text={
-                        "nn": "eit skriftstykke, eit skriftleg utgreiing og inneheld informasjon. Eit dokument er meint for kommunikasjon eller lagring av data. "
-                    },
-                    sourceRelationship="basertPåKilde",
-                    sources=[
-                        TextAndURI(
-                            uri="http://example.com/", text={"nb": "Noe sted et sted"}
-                        )
-                    ],
-                )
-            ],
+            definition=Definition(
+                text={
+                    "nn": "eit skriftstykke, eit skriftleg utgreiing og inneheld informasjon. Eit dokument er meint for kommunikasjon eller lagring av data. "
+                },
+                sourceRelationship="basertPåKilde",
+                sources=[
+                    TextAndURI(
+                        uri="http://example.com/", text={"nb": "Noe sted et sted"}
+                    )
+                ],
+            ),
             type="concept",
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/523ff894-638b-44a2-a4fd-3e96a5a8a5a3": Concept(
@@ -268,14 +260,12 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
                 uri="https://organizations.fellesdatakatalog.digdir.no/organizations/910258028",
             ),
             prefLabel={"nb": "Testbegrep"},
-            definition=[
-                Definition(
-                    text={"nb": "Et begrep som en bruke til å teste med"},
-                    targetGroup="allmennheten",
-                    sourceRelationship="sitatFraKilde",
-                    range=TextAndURI(uri="http://example.com/", text={"nb": "test"}),
-                )
-            ],
+            definition=Definition(
+                text={"nb": "Et begrep som en bruke til å teste med"},
+                targetGroup="allmennheten",
+                sourceRelationship="sitatFraKilde",
+                range=TextAndURI(uri="http://example.com/", text={"nb": "test"}),
+            ),
             type="concept",
         ),
         "https://registrering-begrep-api.staging.fellesdatakatalog.digdir.no/910258028/c4ae179e-6a3a-42bc-85a2-1e32d75fc013": Concept(
@@ -289,17 +279,13 @@ def test_parse_concepts(mock_organizations_and_reference_data: Mock) -> None:
             ),
             application=[{"nb": "hjem"}],
             prefLabel={"nn": "lua og sokka"},
-            contactPoint=[
-                ContactPoint(
-                    email="informasjonsforvaltning@brreg.no",
-                    hasTelephone="+4775007500",
-                )
-            ],
-            definition=[
-                Definition(
-                    text={"nb": "klesplagg for hode og hender"},
-                )
-            ],
+            contactPoint=ContactPoint(
+                email="informasjonsforvaltning@brreg.no",
+                hasTelephone="+4775007500",
+            ),
+            definition=Definition(
+                text={"nb": "klesplagg for hode og hender"},
+            ),
             seeAlso={
                 "http://begrepskatalogen/begrep/be5d8b8b-c3fb-11e9-8d53-005056825ca0",
                 "http://begrepskatalogen/begrep/20b2e2ab-9fe1-11e5-a9f8-e4115b280940",
@@ -421,14 +407,12 @@ def test_parse_concept_with_old_skosno(
         ),
         prefLabel={"nb": "Testbegrep"},
         application=[{"nb": "arbeid"}],
-        definition=[
-            Definition(
-                text={"nb": "Et begrep som en bruke til å teste med"},
-                targetGroup="allmennheten",
-                sourceRelationship="sitatFraKilde",
-                range=TextAndURI(uri="http://example.com/", text={"nb": "test"}),
-            )
-        ],
+        definition=Definition(
+            text={"nb": "Et begrep som en bruke til å teste med"},
+            targetGroup="allmennheten",
+            sourceRelationship="sitatFraKilde",
+            range=TextAndURI(uri="http://example.com/", text={"nb": "test"}),
+        ),
         type="concept",
     )
 


### PR DESCRIPTION
Med commit nr to så tror jeg json som blir produsert skal være lik json fra den gamle høsteren

Begrepet testnivå i staging:
![Screenshot from 2021-05-06 08-03-56](https://user-images.githubusercontent.com/50194012/117250013-dafcb080-ae42-11eb-8f6b-2046d1e83ea4.png)


Samme begrep i prod:
![Screenshot from 2021-05-06 08-04-09](https://user-images.githubusercontent.com/50194012/117250044-e6e87280-ae42-11eb-9d4d-cfc1cf8f0196.png)
