### PR TITLE
fix: extend MediaType from uri and add missing MediaType properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "1.0.1"
+version = "1.0.2"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 

--- a/src/fdk_rdf_parser/classes/__init__.py
+++ b/src/fdk_rdf_parser/classes/__init__.py
@@ -20,6 +20,7 @@ from .harvest_meta_data import HarvestMetaData
 from .info_model import InformationModel
 from .legal_resource import LegalResource
 from .lifeEvent import LifeEvent
+from .media_type import MediaType
 from .output import Output
 from .participation import Participation
 from .public_service import PublicService

--- a/src/fdk_rdf_parser/classes/dataservice.py
+++ b/src/fdk_rdf_parser/classes/dataservice.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Set
 from .catalog import Catalog
 from .dcat_resource import PartialDcatResource
 from .harvest_meta_data import HarvestMetaData
+from .media_type import MediaType
 from .skos_code import SkosCode
 from .skos_concept import SkosConcept
 
@@ -16,6 +17,7 @@ class DataService(PartialDcatResource):
     endpointDescription: Optional[Set[str]] = None
     endpointURL: Optional[Set[str]] = None
     mediaType: Optional[List[SkosCode]] = None
+    dcatMediaType: Optional[List[MediaType]] = None
     servesDataset: Optional[Set[str]] = None
     conformsTo: Optional[List[SkosConcept]] = None
     catalog: Optional[Catalog] = None

--- a/src/fdk_rdf_parser/classes/distribution.py
+++ b/src/fdk_rdf_parser/classes/distribution.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Set
 
 from .conforms_to import ConformsTo
 from .data_distribution_service import DataDistributionService
+from .media_type import MediaType
 from .skos_code import SkosCode
 from .skos_concept import SkosConcept
 
@@ -20,5 +21,10 @@ class Distribution:
     page: Optional[List[SkosConcept]] = None
     mediaType: Optional[List[SkosCode]] = None
     format: Optional[Set[str]] = None
+    dctFormat: Optional[List[MediaType]] = None
+    dcatMediaType: Optional[List[MediaType]] = None
+    fdkFormat: Optional[List[MediaType]] = None
+    compressFormat: Optional[MediaType] = None
+    packageFormat: Optional[MediaType] = None
     type: Optional[str] = None
     accessService: Optional[List[DataDistributionService]] = None

--- a/src/fdk_rdf_parser/classes/media_type.py
+++ b/src/fdk_rdf_parser/classes/media_type.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class MediaType:
+    uri: Optional[str] = None
+    code: Optional[str] = None
+    name: Optional[str] = "UNKNOWN"
+
+    def __hash__(self: Any) -> int:
+        return hash((self.uri, self.code, self.name))

--- a/src/fdk_rdf_parser/parse_functions/dataservice.py
+++ b/src/fdk_rdf_parser/parse_functions/dataservice.py
@@ -11,6 +11,7 @@ from fdk_rdf_parser.rdf_utils import (
 from .catalog import parse_catalog
 from .dcat_resource import parse_dcat_resource
 from .harvest_meta_data import extract_meta_data
+from .media_type import extract_media_type_list
 from .skos_code import extract_skos_code_list
 from .skos_concept import extract_skos_concept
 
@@ -29,6 +30,9 @@ def parse_data_service(
             data_services_graph, data_service_uri, dcat_uri("endpointDescription")
         ),
         mediaType=extract_skos_code_list(
+            data_services_graph, data_service_uri, dcat_uri("mediaType")
+        ),
+        dcatMediaType=extract_media_type_list(
             data_services_graph, data_service_uri, dcat_uri("mediaType")
         ),
         conformsTo=extract_skos_concept(

--- a/src/fdk_rdf_parser/parse_functions/distribution.py
+++ b/src/fdk_rdf_parser/parse_functions/distribution.py
@@ -14,6 +14,7 @@ from fdk_rdf_parser.rdf_utils import (
 )
 from .conforms_to import extract_conforms_to
 from .data_distribution_service import extract_data_distribution_services
+from .media_type import extract_media_type, extract_media_type_list
 from .skos_concept import extract_skos_concept
 
 
@@ -37,6 +38,16 @@ def extract_distributions(
                 conformsTo=extract_conforms_to(graph, resource),
                 page=extract_skos_concept(graph, resource, FOAF.page),
                 format=value_set(graph, resource, dct_uri("format")),
+                dctFormat=extract_media_type_list(graph, resource, dct_uri("format")),
+                dcatMediaType=extract_media_type_list(
+                    graph, resource, dcat_uri("mediaType")
+                ),
+                compressFormat=extract_media_type(
+                    graph, resource, dcat_uri("compressFormat")
+                ),
+                packageFormat=extract_media_type(
+                    graph, resource, dcat_uri("packageFormat")
+                ),
                 type=object_value(graph, resource, DCTERMS.type),
                 accessService=extract_data_distribution_services(graph, resource),
             )

--- a/src/fdk_rdf_parser/parse_functions/media_type.py
+++ b/src/fdk_rdf_parser/parse_functions/media_type.py
@@ -1,0 +1,37 @@
+import logging
+from typing import List, Optional
+
+from rdflib import BNode, Graph, URIRef
+
+from fdk_rdf_parser.classes import MediaType
+
+
+def extract_media_type(
+    graph: Graph, subject: URIRef, predicate: URIRef
+) -> Optional[MediaType]:
+    value = graph.value(subject, predicate)
+    if not value or isinstance(value, BNode):
+        logging.error(
+            f"Unable to parse {predicate.toPython()} for {subject.toPython()}"
+        )
+        return None
+    elif isinstance(value, URIRef):
+        return MediaType(uri=value.toPython())
+    else:
+        return MediaType(code=value.toPython())
+
+
+def extract_media_type_list(
+    graph: Graph, subject: URIRef, predicate: URIRef
+) -> Optional[List[MediaType]]:
+    media_types = []
+    for obj in graph.objects(subject, predicate):
+        if isinstance(obj, BNode):
+            logging.error(
+                f"Unable to parse {predicate.toPython()} for {subject.toPython()}"
+            )
+        elif isinstance(obj, URIRef):
+            media_types.append(MediaType(uri=obj.toPython()))
+        else:
+            media_types.append(MediaType(code=obj.toPython()))
+    return media_types if len(media_types) > 0 else None

--- a/src/fdk_rdf_parser/reference_data/reference_data.py
+++ b/src/fdk_rdf_parser/reference_data/reference_data.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from fdk_rdf_parser.classes import SkosCode, ThemeEU, ThemeLOS
+from fdk_rdf_parser.classes import MediaType, SkosCode, ThemeEU, ThemeLOS
 from .reference_data_client import get_reference_data
 from .utils import remove_trailing_slash
 
 
 @dataclass
 class DataServiceReferenceData:
-    media_types: Optional[Dict[str, SkosCode]] = None
+    media_types: Optional[Dict[str, MediaType]] = None
 
 
 @dataclass
@@ -22,7 +22,7 @@ class DatasetReferenceData:
     location: Optional[Dict[str, SkosCode]] = None
     eu_themes: Optional[Dict[str, ThemeEU]] = None
     los_themes: Optional[Dict[str, ThemeLOS]] = None
-    media_types: Optional[Dict[str, SkosCode]] = None
+    media_types: Optional[Dict[str, MediaType]] = None
 
 
 @dataclass
@@ -113,18 +113,18 @@ def get_and_map_themes_los() -> Optional[Dict[str, ThemeLOS]]:
     return mapped if len(mapped) > 0 else None
 
 
-def get_and_map_media_types() -> Optional[Dict[str, SkosCode]]:
+def get_and_map_media_types() -> Optional[Dict[str, MediaType]]:
     media_types = {}
     codes = get_reference_data("/codes/mediatypes")
     if codes is not None:
         for code in codes:
-            if code.get("code"):
-                media_types[str(code.get("code"))] = SkosCode(
-                    code=str(code.get("code")),
-                    prefLabel={"nb": str(code.get("name"))}
-                    if code.get("name")
-                    else None,
-                )
+            media_type = MediaType(
+                uri=str(code["uri"]) if code.get("uri") else None,
+                code=str(code["code"]) if code.get("code") else None,
+                name=str(code["name"]) if code.get("name") else None,
+            )
+            if media_type.uri:
+                media_types[media_type.uri] = media_type
 
     return media_types if len(media_types) > 0 else None
 

--- a/src/fdk_rdf_parser/reference_data/utils.py
+++ b/src/fdk_rdf_parser/reference_data/utils.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, List, Optional
 
-from fdk_rdf_parser.classes import Reference, SkosCode, ThemeEU, ThemeLOS
+from fdk_rdf_parser.classes import MediaType, Reference, SkosCode, ThemeEU, ThemeLOS
 
 base_url = os.getenv(
     "REFERENCE_DATA_BASE_URI",
@@ -106,6 +106,14 @@ def extend_skos_code_list(
             else:
                 extended_codes.append(code)
         return extended_codes
+
+
+def map_media_type_to_skos_code(media_type: MediaType) -> SkosCode:
+    return SkosCode(
+        uri=media_type.uri,
+        code=media_type.code,
+        prefLabel={"nb": media_type.name if media_type.name else "UNKNOWN"},
+    )
 
 
 def remove_trailing_slash(uri: str) -> str:

--- a/tests/json_data/mediatypes.json
+++ b/tests/json_data/mediatypes.json
@@ -1,41 +1,53 @@
 [
     {
+        "uri": "https://www.iana.org/assignments/media-types/text/csv",
         "code": "text/csv",
         "name": "CSV"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/text/html",
         "code": "text/html",
         "name": "HTML"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/application/json",
         "code": "application/json",
         "name": "JSON"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/application/rdf+xml",
         "code": "application/rdf+xml",
         "name": "RDF/XML"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/text/plain",
         "code": "text/plain",
         "name": "TXT"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/application/xml",
         "code": "application/xml",
         "name": "XML"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/application/ld+json",
         "code": "application/ld+json",
         "name": "JSON-LD"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/text/turtle",
         "code": "text/turtle",
         "name": "Turtle"
     },
     {
+        "uri": "https://www.iana.org/assignments/media-types/application/vnd.geo+json",
         "code": "application/vnd.geo+json",
         "name": "geoJSON"
     },
     {
         "name": "UNKNOWN"
+    },
+    {
+        "code": "text/unknown+code"
     }
 ]

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -6,6 +6,7 @@ from fdk_rdf_parser.classes import (
     ContactPoint,
     DataService,
     HarvestMetaData,
+    MediaType,
     Publisher,
     SkosCode,
     SkosConcept,
@@ -58,7 +59,7 @@ def test_parse_multiple_data_services(
                                   ] ;
         dcat:endpointDescription  <http://example.com/dette%20skal%20v%C3%A6re%20en%20lenke> , <http://example.com/Dette%20er%20en%20test> ;
         dcat:endpointURL          <http://kaffe.no> , <https://kaffemaskin.no> ;
-        dcat:mediaType            <https://www.iana.org/assignments/media-types/text/turtle> , <https://www.iana.org/assignments/media-types/application/rdf+xml> , <https://www.iana.org/assignments/media-types/application/json> ;
+        dcat:mediaType            <https://www.iana.org/assignments/media-types/text/turtle> ;
         dcat:servesDataset        <http://testutgiver.no/datasets/abc> .
 
 <https://testdirektoratet.no/dataservices/111>
@@ -95,7 +96,7 @@ def test_parse_multiple_data_services(
                                   ] ;
         dcat:endpointDescription  <http://example.com/> ;
         dcat:endpointURL          <https://vg.no> ;
-        dcat:mediaType            <https://www.iana.org/assignments/media-types/application/vnd.geo+json> , <https://www.iana.org/assignments/media-types/application/vnd.oasis.opendocument.spreadsheet> .
+        dcat:mediaType            <https://www.iana.org/assignments/media-types/application/vnd.oasis.opendocument.spreadsheet> .
 
 <https://testdirektoratet.no/dataservices/000>
         a                  dcat:CatalogRecord ;
@@ -153,11 +154,18 @@ def test_parse_multiple_data_services(
             },
             endpointURL={"http://kaffe.no", "https://kaffemaskin.no"},
             mediaType=[
-                SkosCode(uri=None, code="application/json", prefLabel={"nb": "JSON"}),
                 SkosCode(
-                    uri=None, code="application/rdf+xml", prefLabel={"nb": "RDF/XML"}
+                    uri="https://www.iana.org/assignments/media-types/text/turtle",
+                    code="text/turtle",
+                    prefLabel={"nb": "Turtle"},
                 ),
-                SkosCode(uri=None, code="text/turtle", prefLabel={"nb": "Turtle"}),
+            ],
+            dcatMediaType=[
+                MediaType(
+                    uri="https://www.iana.org/assignments/media-types/text/turtle",
+                    code="text/turtle",
+                    name="Turtle",
+                ),
             ],
             servesDataset={"http://testutgiver.no/datasets/abc"},
             conformsTo=[
@@ -221,11 +229,10 @@ def test_parse_multiple_data_services(
             ),
             endpointDescription={"http://example.com/"},
             endpointURL={"https://vg.no"},
-            mediaType=[
-                SkosCode(
-                    uri=None,
-                    code="application/vnd.geo+json",
-                    prefLabel={"nb": "geoJSON"},
+            dcatMediaType=[
+                MediaType(
+                    uri="https://www.iana.org/assignments/media-types/application/vnd.oasis.opendocument.spreadsheet",
+                    name="UNKNOWN",
                 ),
             ],
             catalog=Catalog(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,6 +1,6 @@
 from rdflib import Graph, URIRef
 
-from fdk_rdf_parser.classes import ConformsTo, Distribution, SkosConcept
+from fdk_rdf_parser.classes import ConformsTo, Distribution, MediaType, SkosConcept
 from fdk_rdf_parser.parse_functions import extract_distributions
 from fdk_rdf_parser.rdf_utils import dcat_uri
 
@@ -42,6 +42,7 @@ def test_single_distribution() -> None:
             title={"nb": "Testdistribusjon"},
             description={"en": "Description"},
             format={"json"},
+            dctFormat=[MediaType(uri=None, code="json", name="UNKNOWN")],
             license=[
                 SkosConcept(uri="https://creativecommons.org/licenses/by/4.0/deed.no")
             ],
@@ -93,6 +94,7 @@ def test_multiple_distributions() -> None:
             title={"nb": "Testdistribusjon"},
             description={"nb": "Distribusjon json"},
             format={"json"},
+            dctFormat=[MediaType(code="json", name="UNKNOWN")],
             license=[
                 SkosConcept(uri="https://creativecommons.org/licenses/by/4.0/deed.no")
             ],
@@ -103,6 +105,7 @@ def test_multiple_distributions() -> None:
             title={"nb": "Testdistribusjon"},
             description={"nb": "Distribusjon xml"},
             format={"xml"},
+            dctFormat=[MediaType(code="xml", name="UNKNOWN")],
             license=[
                 SkosConcept(uri="https://creativecommons.org/licenses/by/4.0/deed.no")
             ],

--- a/tests/test_extend_data_service_with_reference_data.py
+++ b/tests/test_extend_data_service_with_reference_data.py
@@ -1,4 +1,4 @@
-from fdk_rdf_parser.classes import DataService, SkosCode
+from fdk_rdf_parser.classes import DataService, MediaType, SkosCode
 from fdk_rdf_parser.reference_data import (
     DataServiceReferenceData,
     extend_data_service_with_reference_data,
@@ -9,6 +9,7 @@ from .testdata import data_service_reference_data
 def test_handles_missing_references() -> None:
     parsed_data_service = DataService(
         mediaType=[SkosCode(uri="http://example.com/media-type/text/csv")],
+        dcatMediaType=[MediaType(uri="http://example.com/media-type/text/csv")],
     )
 
     assert (
@@ -22,26 +23,45 @@ def test_handles_missing_references() -> None:
 def test_handles_empty_media_type() -> None:
     parsed_data_service = DataService(
         mediaType=[SkosCode()],
+        dcatMediaType=[MediaType()],
     )
 
     assert (
         extend_data_service_with_reference_data(
             parsed_data_service, data_service_reference_data
         )
-        == DataService()
+        == parsed_data_service
     )
 
 
 def test_extend_media_types() -> None:
     parsed_data_service = DataService(
         mediaType=[
-            SkosCode(uri="http://example.com/media-type/text/csv"),
+            SkosCode(uri="https://www.iana.org/assignments/media-types/text/csv"),
             SkosCode(uri="http://example.com/media-type/not/found"),
+        ],
+        dcatMediaType=[
+            MediaType(uri="https://www.iana.org/assignments/media-types/text/csv"),
+            MediaType(uri="http://example.com/media-type/not/found"),
         ],
     )
 
     expected = DataService(
-        mediaType=[SkosCode(uri=None, code="text/csv", prefLabel={"nb": "CSV"})]
+        mediaType=[
+            SkosCode(
+                uri="https://www.iana.org/assignments/media-types/text/csv",
+                code="text/csv",
+                prefLabel={"nb": "CSV"},
+            ),
+        ],
+        dcatMediaType=[
+            MediaType(
+                uri="https://www.iana.org/assignments/media-types/text/csv",
+                code="text/csv",
+                name="CSV",
+            ),
+            MediaType(uri="http://example.com/media-type/not/found", name="UNKNOWN"),
+        ],
     )
 
     assert (

--- a/tests/test_extend_dataset_with_reference_data.py
+++ b/tests/test_extend_dataset_with_reference_data.py
@@ -2,6 +2,7 @@ from fdk_rdf_parser.classes import (
     ConceptSchema,
     Dataset,
     Distribution,
+    MediaType,
     Reference,
     SkosCode,
     SkosConcept,
@@ -276,11 +277,15 @@ def test_handles_media_types_with_missing_reference_data() -> None:
 def test_extend_media_types() -> None:
     parsed_dataset = Dataset(
         distribution=[
-            Distribution(format={"application/xml"}),
+            Distribution(
+                format={"https://www.iana.org/assignments/media-types/application/xml"}
+            ),
             Distribution(format={"CSV"}),
             Distribution(format={"json"}),
             Distribution(format={"geo+json"}),
-            Distribution(format={"text/turtle"}),
+            Distribution(
+                format={"https://www.iana.org/assignments/media-types/text/turtle"}
+            ),
             Distribution(format={"Rubbish"}),
             Distribution(),
         ]
@@ -289,42 +294,55 @@ def test_extend_media_types() -> None:
     expected = Dataset(
         distribution=[
             Distribution(
-                format={"application/xml"},
+                format={"https://www.iana.org/assignments/media-types/application/xml"},
                 mediaType=[
-                    SkosCode(uri=None, code="application/xml", prefLabel={"nb": "XML"}),
+                    SkosCode(
+                        uri="https://www.iana.org/assignments/media-types/application/xml",
+                        code="application/xml",
+                        prefLabel={"nb": "XML"},
+                    ),
+                ],
+                fdkFormat=[
+                    MediaType(
+                        uri="https://www.iana.org/assignments/media-types/application/xml",
+                        code="application/xml",
+                        name="XML",
+                    )
                 ],
             ),
             Distribution(
                 format={"CSV"},
-                mediaType=[
-                    SkosCode(uri=None, code="text/csv", prefLabel={"nb": "CSV"}),
-                ],
+                fdkFormat=[MediaType(code="CSV", name="UNKNOWN")],
             ),
             Distribution(
                 format={"json"},
-                mediaType=[
-                    SkosCode(
-                        uri=None, code="application/json", prefLabel={"nb": "JSON"}
-                    ),
-                ],
+                fdkFormat=[MediaType(code="json", name="UNKNOWN")],
             ),
             Distribution(
                 format={"geo+json"},
+                fdkFormat=[MediaType(code="geo+json", name="UNKNOWN")],
+            ),
+            Distribution(
+                format={"https://www.iana.org/assignments/media-types/text/turtle"},
                 mediaType=[
                     SkosCode(
-                        uri=None,
-                        code="application/vnd.geo+json",
-                        prefLabel={"nb": "geoJSON"},
+                        uri="https://www.iana.org/assignments/media-types/text/turtle",
+                        code="text/turtle",
+                        prefLabel={"nb": "Turtle"},
+                    ),
+                ],
+                fdkFormat=[
+                    MediaType(
+                        uri="https://www.iana.org/assignments/media-types/text/turtle",
+                        code="text/turtle",
+                        name="Turtle",
                     ),
                 ],
             ),
             Distribution(
-                format={"text/turtle"},
-                mediaType=[
-                    SkosCode(uri=None, code="text/turtle", prefLabel={"nb": "Turtle"}),
-                ],
+                format={"Rubbish"},
+                fdkFormat=[MediaType(code="Rubbish", name="UNKNOWN")],
             ),
-            Distribution(format={"Rubbish"}, mediaType=[]),
             Distribution(),
         ]
     )

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -1,4 +1,4 @@
-from fdk_rdf_parser.classes import ConceptSchema, SkosCode, ThemeEU, ThemeLOS
+from fdk_rdf_parser.classes import ConceptSchema, MediaType, SkosCode, ThemeEU, ThemeLOS
 from fdk_rdf_parser.reference_data import (
     DataServiceReferenceData,
     DatasetReferenceData,
@@ -77,26 +77,50 @@ org_response_1 = """
 
 data_service_reference_data = DataServiceReferenceData(
     media_types={
-        "text/csv": SkosCode(uri=None, code="text/csv", prefLabel={"nb": "CSV"}),
-        "text/html": SkosCode(uri=None, code="text/html", prefLabel={"nb": "HTML"}),
-        "application/json": SkosCode(
-            uri=None, code="application/json", prefLabel={"nb": "JSON"}
+        "https://www.iana.org/assignments/media-types/text/csv": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/csv",
+            code="text/csv",
+            name="CSV",
         ),
-        "application/rdf+xml": SkosCode(
-            uri=None, code="application/rdf+xml", prefLabel={"nb": "RDF/XML"}
+        "https://www.iana.org/assignments/media-types/text/html": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/html",
+            code="text/html",
+            name="HTML",
         ),
-        "text/plain": SkosCode(uri=None, code="text/plain", prefLabel={"nb": "TXT"}),
-        "application/xml": SkosCode(
-            uri=None, code="application/xml", prefLabel={"nb": "XML"}
+        "https://www.iana.org/assignments/media-types/application/json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/json",
+            code="application/json",
+            name="JSON",
         ),
-        "application/ld+json": SkosCode(
-            uri=None, code="application/ld+json", prefLabel={"nb": "JSON-LD"}
+        "https://www.iana.org/assignments/media-types/application/rdf+xml": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/rdf+xml",
+            code="application/rdf+xml",
+            name="RDF/XML",
         ),
-        "text/turtle": SkosCode(
-            uri=None, code="text/turtle", prefLabel={"nb": "Turtle"}
+        "https://www.iana.org/assignments/media-types/text/plain": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/plain",
+            code="text/plain",
+            name="TXT",
         ),
-        "application/vnd.geo+json": SkosCode(
-            uri=None, code="application/vnd.geo+json", prefLabel={"nb": "geoJSON"}
+        "https://www.iana.org/assignments/media-types/application/xml": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/xml",
+            code="application/xml",
+            name="XML",
+        ),
+        "https://www.iana.org/assignments/media-types/application/ld+json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/ld+json",
+            code="application/ld+json",
+            name="JSON-LD",
+        ),
+        "https://www.iana.org/assignments/media-types/text/turtle": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/turtle",
+            code="text/turtle",
+            name="Turtle",
+        ),
+        "https://www.iana.org/assignments/media-types/application/vnd.geo+json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/vnd.geo+json",
+            code="application/vnd.geo+json",
+            name="geoJSON",
         ),
     }
 )
@@ -625,26 +649,50 @@ dataset_reference_data = DatasetReferenceData(
         ),
     },
     media_types={
-        "text/csv": SkosCode(uri=None, code="text/csv", prefLabel={"nb": "CSV"}),
-        "text/html": SkosCode(uri=None, code="text/html", prefLabel={"nb": "HTML"}),
-        "application/json": SkosCode(
-            uri=None, code="application/json", prefLabel={"nb": "JSON"}
+        "https://www.iana.org/assignments/media-types/text/csv": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/csv",
+            code="text/csv",
+            name="CSV",
         ),
-        "application/rdf+xml": SkosCode(
-            uri=None, code="application/rdf+xml", prefLabel={"nb": "RDF/XML"}
+        "https://www.iana.org/assignments/media-types/text/html": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/html",
+            code="text/html",
+            name="HTML",
         ),
-        "text/plain": SkosCode(uri=None, code="text/plain", prefLabel={"nb": "TXT"}),
-        "application/xml": SkosCode(
-            uri=None, code="application/xml", prefLabel={"nb": "XML"}
+        "https://www.iana.org/assignments/media-types/application/json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/json",
+            code="application/json",
+            name="JSON",
         ),
-        "application/ld+json": SkosCode(
-            uri=None, code="application/ld+json", prefLabel={"nb": "JSON-LD"}
+        "https://www.iana.org/assignments/media-types/application/rdf+xml": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/rdf+xml",
+            code="application/rdf+xml",
+            name="RDF/XML",
         ),
-        "text/turtle": SkosCode(
-            uri=None, code="text/turtle", prefLabel={"nb": "Turtle"}
+        "https://www.iana.org/assignments/media-types/text/plain": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/plain",
+            code="text/plain",
+            name="TXT",
         ),
-        "application/vnd.geo+json": SkosCode(
-            uri=None, code="application/vnd.geo+json", prefLabel={"nb": "geoJSON"}
+        "https://www.iana.org/assignments/media-types/application/xml": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/xml",
+            code="application/xml",
+            name="XML",
+        ),
+        "https://www.iana.org/assignments/media-types/application/ld+json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/ld+json",
+            code="application/ld+json",
+            name="JSON-LD",
+        ),
+        "https://www.iana.org/assignments/media-types/text/turtle": MediaType(
+            uri="https://www.iana.org/assignments/media-types/text/turtle",
+            code="text/turtle",
+            name="Turtle",
+        ),
+        "https://www.iana.org/assignments/media-types/application/vnd.geo+json": MediaType(
+            uri="https://www.iana.org/assignments/media-types/application/vnd.geo+json",
+            code="application/vnd.geo+json",
+            name="geoJSON",
         ),
     },
 )


### PR DESCRIPTION
Distribution har 4 relevante egenskaper: dct:format, dcat:mediaType, dcat:compressFormat og dcat:packageFormat

`dataset.distribution` har to eksisterende felt ang. mediaType, dvs 'format' og 'mediaType'
'format' er en liste Literals ut fra verdiene fra dct:format
Deretter prøver den å koble verdiene fra 'format' til data reference-data, dette blir lagt til i 'mediaType' som objekttype 'SkosCode'

Dvs data fra dcat:mediaType, dcat:compressFormat og dcat:packageFormat blir ikke brukt

Beholder eksisterende felt as-is, men legger til 5 nye felt:
- dctFormat: verdiene fra dct:format, utvidet med data fra reference-data
- dcatMediaType: verdiene fra dcat:mediaType, utvidet med data fra reference-data
- fdkFormat: slår sammen dctFormat og dcatMediaType til bruk i mediatype-filteret
- compressFormat: verdiene fra dcat:compressFormat, utvidet med data fra reference-data
- packageFormat: verdiene fra dcat:packageFormat, utvidet med data fra reference-data