### PR TITLE
fix: orgUnit & orgName is language fields in contact point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fdk-rdf-parser"
-version = "2.0.5"
+version = "2.1.0"
 description = ""
 authors = ["NilsOveTen <nils.ove.tendenes@digdir.no>"]
 

--- a/src/fdk_rdf_parser/classes/contactpoint.py
+++ b/src/fdk_rdf_parser/classes/contactpoint.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 
 @dataclass
@@ -7,7 +7,7 @@ class ContactPoint:
     uri: Optional[str] = None
     fullname: Optional[str] = None
     email: Optional[str] = None
-    organizationName: Optional[str] = None
-    organizationUnit: Optional[str] = None
+    organizationName: Optional[Dict[str, str]] = None
+    organizationUnit: Optional[Dict[str, str]] = None
     hasURL: Optional[str] = None
     hasTelephone: Optional[str] = None

--- a/src/fdk_rdf_parser/parse_functions/contactpoint.py
+++ b/src/fdk_rdf_parser/parse_functions/contactpoint.py
@@ -3,7 +3,13 @@ from typing import Any, List, Optional
 from rdflib import Graph, URIRef
 
 from fdk_rdf_parser.classes import ContactPoint
-from fdk_rdf_parser.rdf_utils import dcat_uri, object_value, resource_list, vcard_uri
+from fdk_rdf_parser.rdf_utils import (
+    dcat_uri,
+    object_value,
+    resource_list,
+    value_translations,
+    vcard_uri,
+)
 
 
 def extract_contact_points(
@@ -20,10 +26,10 @@ def extract_contact_points(
                 uri=resource_uri,
                 fullname=object_value(graph, resource, vcard_uri("fn")),
                 email=extract_has_email(graph, resource),
-                organizationName=object_value(
+                organizationName=value_translations(
                     graph, resource, vcard_uri("hasOrganizationName")
                 ),
-                organizationUnit=object_value(
+                organizationUnit=value_translations(
                     graph, resource, vcard_uri("organization-unit")
                 ),
                 hasURL=object_value(graph, resource, vcard_uri("hasURL")),

--- a/tests/test_contactpoint.py
+++ b/tests/test_contactpoint.py
@@ -15,13 +15,13 @@ def test_single_contact_point() -> None:
                 dcat:contactPoint
                     [ a                          vcard:Organization ;
                       vcard:hasTelephone         "23453345" ;
-                      vcard:hasOrganizationName  "Testdirektoratet" ;
+                      vcard:hasOrganizationName  "Testdirektoratet"@nb ;
                       vcard:hasURL               <https://testdirektoratet.no>
                     ] ."""
 
     expected = [
         ContactPoint(
-            organizationName="Testdirektoratet",
+            organizationName={"nb": "Testdirektoratet"},
             hasURL="https://testdirektoratet.no",
             hasTelephone="23453345",
         )
@@ -47,8 +47,8 @@ def test_several_contact_points() -> None:
                 dcat:contactPoint
                     [ a                          vcard:Organization ;
                       vcard:hasEmail             "post@mail.com" ;
-                      vcard:hasOrganizationName  "Testdirektoratet" ;
-                      vcard:organization-unit    "Testenhet" ;
+                      vcard:hasOrganizationName  "Testdirektoratet"@nb , "Testdirektoratet"@nn , "Directorate of test"@en ;
+                      vcard:organization-unit    "Testenhet"@nb , "Testenhet"@nn , "Test unit"@en ;
                       vcard:hasURL               <https://testdirektoratet.no>
                     ] ;
                 dcat:contactPoint
@@ -65,8 +65,12 @@ def test_several_contact_points() -> None:
     expected = [
         ContactPoint(
             email="post@mail.com",
-            organizationName="Testdirektoratet",
-            organizationUnit="Testenhet",
+            organizationName={
+                "nb": "Testdirektoratet",
+                "nn": "Testdirektoratet",
+                "en": "Directorate of test",
+            },
+            organizationUnit={"nb": "Testenhet", "nn": "Testenhet", "en": "Test unit"},
             hasURL="https://testdirektoratet.no",
         ),
         ContactPoint(

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -153,7 +153,7 @@ def test_parse_multiple_data_services(
                 ContactPoint(
                     fullname="Contact information",
                     email="kaffe@epost.no",
-                    organizationName="Kaffehuset",
+                    organizationName={"nb": "Kaffehuset"},
                     hasURL="http://www.kaffehuset.no",
                 )
             ],


### PR DESCRIPTION
fixes #141 