### PR TITLE
feat: update hasLegalResource

### DIFF
--- a/src/fdk_rdf_parser/classes/legal_resource.py
+++ b/src/fdk_rdf_parser/classes/legal_resource.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import (
     Dict,
+    List,
     Optional,
 )
 
@@ -8,5 +9,7 @@ from typing import (
 @dataclass
 class LegalResource:
     uri: Optional[str] = None
+    dctTitle: Optional[Dict[str, str]] = None
     description: Optional[Dict[str, str]] = None
-    url: Optional[str] = None
+    seeAlso: Optional[List[str]] = None
+    relation: Optional[List[str]] = None

--- a/src/fdk_rdf_parser/parse_functions/legal_resource.py
+++ b/src/fdk_rdf_parser/parse_functions/legal_resource.py
@@ -15,8 +15,8 @@ from rdflib.namespace import (
 
 from fdk_rdf_parser.classes import LegalResource
 from fdk_rdf_parser.rdf_utils import (
-    object_value,
     resource_list,
+    value_list,
     value_translations,
 )
 
@@ -30,8 +30,10 @@ def extract_legal_resources(
         values.append(
             LegalResource(
                 uri=resource_uri,
+                dctTitle=value_translations(graph, resource, DCTERMS.title),
                 description=value_translations(graph, resource, DCTERMS.description),
-                url=object_value(graph, resource, RDFS.seeAlso),
+                seeAlso=value_list(graph, resource, RDFS.seeAlso),
+                relation=value_list(graph, resource, DCTERMS.relation),
             )
         )
 

--- a/tests/test_public_service.py
+++ b/tests/test_public_service.py
@@ -239,8 +239,13 @@ def test_complete_public_services(
                     cpsv:implements     <http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/1> .
 
             <http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/1> a eli:LegalResource ;
+                    dct:title           "Lov om Enhetsregisteret"@nb ;
                     dct:description     "Lov om Enhetsregisteret"@nb ;
-                    rdfs:seeAlso         <https://lovdata.no/eli/lov/1994/06/03/15/nor/html> ; .
+                    rdfs:seeAlso        <https://lovdata.no/eli/lov/1994/06/03/15/nor/html> ;
+                    dct:relation        <http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/2> .
+
+            <http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/2> a eli:LegalResource ;
+                    dct:title           "Annen regulativ ressurs"@nb .
 
             <https://data.brreg.no/enhetsregisteret/api/enheter/971526920> a dct:Agent ;
                     dct:identifier "971526920" ;
@@ -721,8 +726,12 @@ def test_complete_public_services(
             hasLegalResource=[
                 LegalResource(
                     uri="http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/1",
+                    dctTitle={"nb": "Lov om Enhetsregisteret"},
                     description={"nb": "Lov om Enhetsregisteret"},
-                    url="https://lovdata.no/eli/lov/1994/06/03/15/nor/html",
+                    seeAlso=["https://lovdata.no/eli/lov/1994/06/03/15/nor/html"],
+                    relation=[
+                        "http://public-service-publisher.fellesdatakatalog.digdir.no/legalresource/2"
+                    ],
                 )
             ],
             hasChannel=[


### PR DESCRIPTION
* includes dct:title, dct:relation and rdfs:seeAlso

BREAKING CHANGE: LegalResource-field 'url' has been renamed to 'seeAlso'.

resolves #172 