### PR TITLE
fix: rm channel extract from cost

### DIFF
--- a/src/fdk_rdf_parser/classes/cost.py
+++ b/src/fdk_rdf_parser/classes/cost.py
@@ -5,7 +5,6 @@ from typing import (
     Optional,
 )
 
-from .channel import Channel
 from .publisher import Publisher
 
 
@@ -15,6 +14,6 @@ class Cost:
     identifier: Optional[str] = None
     description: Optional[Dict[str, str]] = None
     currency: Optional[str] = None
-    ifAccessedThrough: Optional[Channel] = None
+    ifAccessedThrough: Optional[str] = None
     isDefinedBy: Optional[List[Publisher]] = None
     value: Optional[str] = None

--- a/src/fdk_rdf_parser/parse_functions/cost.py
+++ b/src/fdk_rdf_parser/parse_functions/cost.py
@@ -17,7 +17,6 @@ from fdk_rdf_parser.rdf_utils import (
     resource_list,
     value_translations,
 )
-from .channel import extract_channels
 from .publisher import extract_list_of_publishers
 
 
@@ -25,16 +24,15 @@ def extract_costs(graph: Graph, subject: URIRef) -> Optional[List[Cost]]:
     values = []
     for resource in resource_list(graph, subject, cv_uri("hasCost")):
         resource_uri = resource.toPython() if isinstance(resource, URIRef) else None
-        channels = extract_channels(graph, resource, cv_uri("ifAccessedThrough"))
         values.append(
             Cost(
                 uri=resource_uri,
                 identifier=object_value(graph, resource, DCTERMS.identifier),
                 description=value_translations(graph, resource, DCTERMS.description),
                 currency=object_value(graph, resource, cv_uri("currency")),
-                ifAccessedThrough=channels[0]
-                if channels is not None and len(channels) == 1
-                else None,
+                ifAccessedThrough=object_value(
+                    graph, resource, cv_uri("ifAccessedThrough")
+                ),
                 isDefinedBy=extract_list_of_publishers(
                     graph, resource, cv_uri("isDefinedBy")
                 ),

--- a/tests/test_public_service.py
+++ b/tests/test_public_service.py
@@ -128,7 +128,7 @@ def test_complete_public_services(
             <http://public-service-publisher.fellesdatakatalog.digdir.no/cost/15>
                     a  cv:Cost ;
                     cv:currency           <http://publications.europa.eu/resource/authority/currency/NOK> ;
-                    cv:ifAccessedThrough  <http://public-service-publisher.fellesdatakatalog.digdir.no/channel/10> ;
+                    cv:ifAccessedThrough  <http://public-service-publisher.fellesdatakatalog.digdir.no/channel/2> ;
                     cv:isDefinedBy        <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/123456789> ;
                     cv:value              4.27 ;
                     dct:description       "4,27 kr pr. vareliter for alkoholholdig drikk i gruppe 3" ;
@@ -144,12 +144,6 @@ def test_complete_public_services(
                     a cv:Channel ;
                     cv:ownedBy      <http://public-service-publisher.fellesdatakatalog.digdir.no/public-organisation/1> ;
                     dct:identifier  "2" ;
-                    dct:type        <https://data.norge.no/concepts/257> .
-
-            <http://public-service-publisher.fellesdatakatalog.digdir.no/channel/10>
-                    a cv:Channel ;
-                    cv:ownedBy      <https://organization-catalog.fellesdatakatalog.digdir.no/organizations/123456789> ;
-                    dct:identifier  "10" ;
                     dct:type        <https://data.norge.no/concepts/257> .
 
             <http://public-service-publisher.fellesdatakatalog.digdir.no/requirement/5>
@@ -760,14 +754,7 @@ def test_complete_public_services(
                         "nb": "4,27 kr pr. vareliter for alkoholholdig drikk i gruppe 3"
                     },
                     currency="http://publications.europa.eu/resource/authority/currency/NOK",
-                    ifAccessedThrough=Channel(
-                        uri="http://public-service-publisher.fellesdatakatalog.digdir.no/channel/10",
-                        identifier="10",
-                        type=SkosConcept(
-                            uri="https://data.norge.no/concepts/257",
-                            prefLabel={"nb": "Post", "en": "Mail"},
-                        ),
-                    ),
+                    ifAccessedThrough="http://public-service-publisher.fellesdatakatalog.digdir.no/channel/2",
                     isDefinedBy=[
                         Publisher(
                             uri="https://organization-catalog.fellesdatakatalog.digdir.no/organizations/123456789",


### PR DESCRIPTION
Gebyr er ikke en del av denne leveransen, så vi kan strengt tatt bare fjerne hele greia. Men jeg prøvde å fikse det slik jeg tipper vi vil har det senere. As is blir det uansett problem mtp endringene Hege gjør i Channel.

Det jeg tipper de vil ha senere er type scroll-link vi har andre steder. Så bare fjernet at den brukte Cost-objektet og har kun uri slik at den kan bruke scroll-link når den tid kommer. Vi får gjøre eventuelle oppdateringer til neste leveranse om jeg tar feil :shrug: 